### PR TITLE
Await Perform.doSetUser to fix refresh token expiry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,9 +34,15 @@ const App: React.FC<IAppProps> = props => {
 
       if (LSAccess && LSRefresh && LSId) {
         try {
-          Perform.doSetAccessToken(LSAccess, dispatch);
+          /**
+           * We need to await the doSetUser function, as if not, the error won't be caught
+           * by the catch (e), and the user will not be logged out. This leads to a
+           * situation where you're stuck on the loading screen with an error saying
+           * the refresh token is expired. This is due to the fact that it is async.
+           */
           Perform.doSetRefreshToken(LSRefresh, dispatch);
-          Perform.doSetUser(LSAccess, LSId, dispatch);
+          Perform.doSetAccessToken(LSAccess, dispatch);
+          await Perform.doSetUser(LSAccess, LSId, dispatch);
         } catch (e) {
           Perform.doLogout(dispatch);
         }
@@ -64,16 +70,16 @@ const App: React.FC<IAppProps> = props => {
 
   if (!auth.access) {
     return (
-      <Wrap className={props.className} auth={{store: auth, dispatch}}>
+      <Wrap className={props.className} auth={{ store: auth, dispatch }}>
         <Route path="/" exact={true} component={Login} />
         <Route path="/register" component={Register} />
-        {pageRoutes.map(e => <Route key={e} to={e}><Redirect to="/" /></Route> )}
+        {pageRoutes.map(e => <Route key={e} to={e}><Redirect to="/" /></Route>)}
       </Wrap>
     );
   }
 
   return (
-    <Wrap className={props.className} auth={{store: auth, dispatch}}>
+    <Wrap className={props.className} auth={{ store: auth, dispatch }}>
       <Navigation />
       <Page>
         <Route path="/" exact={true} component={Homepage} />

--- a/src/mitochondria/auth.ts
+++ b/src/mitochondria/auth.ts
@@ -72,13 +72,13 @@ export const fetchNewToken = async (): Promise<string> => {
   });
 
   switch (res.status) {
-  case 200:
-    return (await res.json() as ITokenResponse).access;
-  case 401:
-    // The refresh token has expired
-    throw new Error('Refresh token has expired.');
-  default:
-    throw new Error('Unexpected response from server.');
+    case 200:
+      return (await res.json() as ITokenResponse).access;
+    case 401:
+      // The refresh token has expired
+      throw new Error('Refresh token has expired.');
+    default:
+      throw new Error('Unexpected response from server.');
   }
 };
 
@@ -86,23 +86,23 @@ export const fetchUserById = async (id: number, token: string): Promise<IUser> =
   const res = await fetch(`${BASE_URL}user/?id=${id}`, { headers: { Authorization: `Bearer ${token}` } });
 
   switch (res.status) {
-  case 200:
-    return await res.json() as IUser;
-  case 400:
-    throw new Error((await res.json() as IError).detail);
-  case 401:
-    try {
-      const newToken = await fetchNewToken();
-      localStorage.setItem('access', newToken);
-      return await fetchUserById(id, newToken);
-    } catch (e) {
-      throw new Error(e);
-    }
+    case 200:
+      return await res.json() as IUser;
+    case 400:
+      throw new Error((await res.json() as IError).detail);
+    case 401:
+      try {
+        const newToken = await fetchNewToken();
+        localStorage.setItem('access', newToken);
+        return await fetchUserById(id, newToken);
+      } catch (e) {
+        throw new Error(e);
+      }
 
-  case 404:
-    throw new Error((await res.json() as IError).detail);
-  default:
-    throw new Error('Unexpected response from server.');
+    case 404:
+      throw new Error((await res.json() as IError).detail);
+    default:
+      throw new Error('Unexpected response from server.');
   }
 };
 


### PR DESCRIPTION
There was a bug where if you opened the app while your access and refresh tokens were expired, you would be stuck on the loading screen as the 401 error wasn't caught due to being called by an async function.