### PR TITLE
Clear tokens before register/login to avoid fail

### DIFF
--- a/src/mitochondria/auth.ts
+++ b/src/mitochondria/auth.ts
@@ -10,6 +10,10 @@ export interface ILoginResponse extends IAuth {
 export const register = async (
   email: string, firstName: string, lastName: string, password: string,
 ): Promise<ILoginResponse> => {
+  // We want to clear the tokens, as if not, it will fail if tokens are outdated when logging in!
+  localStorage.removeItem('access');
+  localStorage.removeItem('refresh');
+
   return await fetchWithCallback('/user/', '', {
     body: JSON.stringify({ email, password, first_name: firstName, last_name: lastName }),
     method: 'POST',
@@ -29,6 +33,10 @@ export const register = async (
 };
 
 export const login = async (email: string, password: string): Promise<ILoginResponse> => {
+  // We want to clear the tokens, as if not, it will fail if tokens are outdated when logging in!
+  localStorage.removeItem('access');
+  localStorage.removeItem('refresh');
+
   return await fetchWithCallback('/user/login/', '', {
     body: JSON.stringify({ email, password }),
     method: 'POST',


### PR DESCRIPTION
It would have failed if the tokens were outdated when trying to log in
or register.