### PR TITLE
Feature/reducers

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import App from '../App';
+import { render } from '../helpers/test-utils';
+
+test('renders app without any problems', () => {
+  expect(() => render(<App />)).not.toThrow();
+});

--- a/src/components/molecules/AddTransaction.tsx
+++ b/src/components/molecules/AddTransaction.tsx
@@ -53,7 +53,7 @@ const AddTransaction: React.FC<IProps> = props => {
         type: transactionType,
       };
       try {
-        TransactionActions.doAddTransaction(formValues, dispatch);
+        TransactionActions.doCreateTransaction(formValues, dispatch);
       } catch (e) {
         setError(e.message);
         /* TODO – handle and display error to the user */

--- a/src/mitochondria/__test__/balances.ts
+++ b/src/mitochondria/__test__/balances.ts
@@ -52,6 +52,12 @@ describe('month', () => {
     expect(resp.balances[0].money).toBe(transaction.money);
   });
 
+  test('get month that does not have any balances', async () => {
+    const resp = await api.getMonth(1, 2000, company.id);
+
+    expect(resp.balances.length).toBe(0);
+  });
+
   test.todo('get month by date range');
 });
 

--- a/src/mitochondria/company.ts
+++ b/src/mitochondria/company.ts
@@ -10,7 +10,7 @@ export const createCompany = (company: Omit<ICompany, 'id' | 'users'>) =>
 export const getCompanyById = (companyId: number) =>
   fetchWithCallback<ICompany>('/company/', `?company_id=${companyId}`);
 
-interface IUpdateCompany extends Pick<ICompany, 'org_nr' | 'name'> {
+export interface IUpdateCompany extends Pick<ICompany, 'org_nr' | 'name'> {
   company_id: number;
 }
 

--- a/src/store/reducers/__tests__/auth.test.ts
+++ b/src/store/reducers/__tests__/auth.test.ts
@@ -1,0 +1,8 @@
+import { initialState } from '../../contexts/auth';
+import { AuthActionCreators, authReducer } from '../auth';
+
+test.todo('Login');
+test.todo('Register');
+test.todo('Logout');
+test.todo('Set user');
+test.todo('Update user');

--- a/src/store/reducers/__tests__/auth.test.ts
+++ b/src/store/reducers/__tests__/auth.test.ts
@@ -1,8 +1,54 @@
+import { IUser } from '../../../declarations/user';
 import { initialState } from '../../contexts/auth';
-import { AuthActionCreators, authReducer } from '../auth';
+import { AuthActionCreators, authReducer, AuthState } from '../auth';
 
-test.todo('Login');
-test.todo('Register');
-test.todo('Logout');
-test.todo('Set user');
-test.todo('Update user');
+const user: IUser = {
+  companies: [],
+  email: 'comedian@liveattheapollo.com',
+  first_name: 'John',
+  id: 0,
+  last_name: 'McMacintyre',
+};
+
+test('login', () => {
+  const resp = authReducer(initialState, AuthActionCreators.login(user));
+  expect(resp).toEqual(user);
+});
+
+test('register', () => {
+  const resp = authReducer(initialState, AuthActionCreators.register(user));
+  expect(resp).toEqual(user);
+});
+
+describe('alter user', () => {
+  let loggedInState: AuthState;
+
+  beforeEach(() => {
+    loggedInState = authReducer(initialState, AuthActionCreators.login(user));
+  });
+
+  test('logout', () => {
+    const resp = authReducer(loggedInState, AuthActionCreators.logout());
+
+    expect(resp).toBeNull();
+  });
+
+  test('update user', () => {
+    const updateParams: Omit<IUser, 'companies'> = {
+      email: 'ding@dong.pingpong',
+      first_name: 'COWA',
+      id: user.id,
+      last_name: 'BUNGA',
+    };
+
+    const resp = authReducer(
+      loggedInState,
+      AuthActionCreators.updateUser(updateParams)
+    );
+
+    expect(resp).toEqual({
+      ...user,
+      ...updateParams,
+    });
+  });
+});

--- a/src/store/reducers/__tests__/company.test.ts
+++ b/src/store/reducers/__tests__/company.test.ts
@@ -1,0 +1,112 @@
+import { ICompany } from '../../../declarations/company';
+import { initialState } from '../../contexts/company';
+import {
+  CompanyActionCreators,
+  companyReducer,
+  CompanyState,
+} from '../company';
+
+const comp: ICompany = {
+  id: 0,
+  name: 'WHAT DID YOU JUST SAY?',
+  org_nr: '424242',
+  users: [
+    {
+      company_id: 0,
+      role: 'OW',
+      user_id: 0,
+    },
+  ],
+};
+
+test('add company', () => {
+  expect(initialState.length).toBe(0);
+  const updatedState = companyReducer(
+    initialState,
+    CompanyActionCreators.addCompany(comp)
+  );
+  expect(updatedState.length).toBe(1);
+  expect(updatedState[0]).toEqual(comp);
+});
+
+describe('alter company', () => {
+  let state: CompanyState;
+
+  beforeEach(() => {
+    state = companyReducer(
+      initialState,
+      CompanyActionCreators.addCompany(comp)
+    );
+  });
+
+  test('update company', () => {
+    const newState = companyReducer(
+      state,
+      CompanyActionCreators.updateCompany({
+        company_id: comp.id,
+        name: 'Supercompany #5',
+        org_nr: comp.org_nr,
+      })
+    );
+
+    expect(newState[0].name).toBe('Supercompany #5');
+  });
+
+  test('delete company', () => {
+    const newState = companyReducer(
+      state,
+      CompanyActionCreators.deleteCompany(comp.id)
+    );
+
+    expect(newState.length).toBe(0);
+  });
+
+  test('add user to company', () => {
+    const newState = companyReducer(
+      state,
+      CompanyActionCreators.addUserToCompany({
+        company_id: comp.id,
+        role: 'RE',
+        user_id: 1,
+      })
+    );
+
+    expect(newState[0].users.length).toBe(2);
+    expect(newState[0].users.find(e => e.user_id === 1)).toBeTruthy();
+  });
+
+  describe('alter users', () => {
+    beforeEach(() => {
+      state = companyReducer(
+        state,
+        CompanyActionCreators.addUserToCompany({
+          company_id: comp.id,
+          role: 'RE',
+          user_id: 1,
+        })
+      );
+    });
+
+    test('remove user from company', () => {
+      const newState = companyReducer(
+        state,
+        CompanyActionCreators.removeUserFromCompany(comp.id, 1)
+      );
+      expect(newState[0].users.length).toBe(1);
+      expect(newState[0].users.find(e => e.user_id === 1)).toBeUndefined();
+    });
+
+    test('set role for user in company', () => {
+      const newState = companyReducer(
+        state,
+        CompanyActionCreators.setRoleForUserInCompany({
+          company_id: comp.id,
+          role: 'OW',
+          user_id: 1,
+        })
+      );
+
+      expect(newState[0].users.find(e => e.user_id === 1)!.role).toBe('OW');
+    });
+  });
+});

--- a/src/store/reducers/__tests__/transactions.test.ts
+++ b/src/store/reducers/__tests__/transactions.test.ts
@@ -11,7 +11,7 @@ const tx: ITransaction = {
   description: 'Test transaction #0',
   id: 0,
   money: 10000,
-  type: 'income',
+  type: 'IN',
 };
 
 test('adds a new transaction', () => {
@@ -33,20 +33,26 @@ test('adds a new transaction', () => {
 
 test('removes a transaction', () => {
   let state = initialState;
+
   expect(state.transactions.length).toBe(0);
+
   state = transactionReducer(
     state,
     TransactionActionCreators.addTransaction(tx)
   );
+
   state = transactionReducer(
     state,
     TransactionActionCreators.addTransaction({ ...tx, id: 1 })
   );
+
   expect(state.transactions.length).toBe(2);
+
   state = transactionReducer(
     state,
-    TransactionActionCreators.removeTransaction(tx)
+    TransactionActionCreators.removeTransaction(tx.company_id, tx.id)
   );
+
   expect(state.transactions.length).toBe(1);
 });
 
@@ -64,7 +70,7 @@ test("doesn't remove if no match", () => {
   expect(state.transactions.length).toBe(2);
   state = transactionReducer(
     state,
-    TransactionActionCreators.removeTransaction({ ...tx, id: 2 })
+    TransactionActionCreators.removeTransaction(tx.company_id, 3)
   );
   expect(state.transactions.length).toBe(2);
 });

--- a/src/store/reducers/auth.ts
+++ b/src/store/reducers/auth.ts
@@ -8,6 +8,7 @@ const LOGIN = 'LOGIN' as const;
 const REGISTER = 'REGISTER' as const;
 const LOGOUT = 'LOGOUT' as const;
 const SET_USER = 'SET_USER' as const;
+const UPDATE_USER = 'UPDATE_USER' as const;
 
 export type AuthState = IUser | null;
 
@@ -60,7 +61,7 @@ const doLogout = (dispatch: React.Dispatch<ICreatedAction>) => {
 };
 
 const setUser = (user: IUser) => ({
-  payload: { user },
+  payload: user,
   type: SET_USER,
 });
 async function doSetUser(id: number, dispatch: React.Dispatch<ICreatedAction>) {
@@ -68,22 +69,43 @@ async function doSetUser(id: number, dispatch: React.Dispatch<ICreatedAction>) {
   dispatch(setUser(user));
 }
 
+type UpdateUser = Omit<IUser, 'companies'>;
+const updateUser = (user: UpdateUser) => ({
+  payload: user,
+  type: UPDATE_USER,
+});
+async function doUpdateUser(
+  user: UpdateUser,
+  dispatch: React.Dispatch<ICreatedAction>
+) {
+  await API.updateUser(user);
+  dispatch(updateUser(user));
+}
+
+async function doDeleteUser(dispatch: React.Dispatch<ICreatedAction>) {
+  await API.deleteUser();
+  dispatch(logout());
+}
+
 /**
  * Under here you will find action creators, the reducer, and created action creators.
  */
 
-const AuthActionCreators = {
+export const AuthActionCreators = {
   login,
   logout,
   register,
   setUser,
+  updateUser,
 };
 
 export const AuthActions = {
+  doDeleteUser,
   doLogin,
   doLogout,
   doRegister,
   doSetUser,
+  doUpdateUser,
 };
 
 // the return types of all the elements in ActionCreators
@@ -104,7 +126,9 @@ export const authReducer = (
     case LOGOUT:
       return null;
     case SET_USER:
-      return action.payload.user;
+      return action.payload;
+    case UPDATE_USER:
+      return { ...action.payload, companies: state!.companies };
   }
 
   return state;

--- a/src/store/reducers/auth.ts
+++ b/src/store/reducers/auth.ts
@@ -7,7 +7,6 @@ import * as API from './../../mitochondria';
 const LOGIN = 'LOGIN' as const;
 const REGISTER = 'REGISTER' as const;
 const LOGOUT = 'LOGOUT' as const;
-const SET_USER = 'SET_USER' as const;
 const UPDATE_USER = 'UPDATE_USER' as const;
 
 export type AuthState = IUser | null;
@@ -60,15 +59,6 @@ const doLogout = (dispatch: React.Dispatch<ICreatedAction>) => {
   dispatch(logout());
 };
 
-const setUser = (user: IUser) => ({
-  payload: user,
-  type: SET_USER,
-});
-async function doSetUser(id: number, dispatch: React.Dispatch<ICreatedAction>) {
-  const user = await API.getUserById(id);
-  dispatch(setUser(user));
-}
-
 type UpdateUser = Omit<IUser, 'companies'>;
 const updateUser = (user: UpdateUser) => ({
   payload: user,
@@ -95,7 +85,6 @@ export const AuthActionCreators = {
   login,
   logout,
   register,
-  setUser,
   updateUser,
 };
 
@@ -104,7 +93,6 @@ export const AuthActions = {
   doLogin,
   doLogout,
   doRegister,
-  doSetUser,
   doUpdateUser,
 };
 
@@ -125,8 +113,6 @@ export const authReducer = (
       return action.payload;
     case LOGOUT:
       return null;
-    case SET_USER:
-      return action.payload;
     case UPDATE_USER:
       return { ...action.payload, companies: state!.companies };
   }

--- a/src/store/reducers/auth.ts
+++ b/src/store/reducers/auth.ts
@@ -77,6 +77,14 @@ async function doDeleteUser(dispatch: React.Dispatch<ICreatedAction>) {
   dispatch(logout());
 }
 
+const doSetUser = async (
+  userId: number,
+  dispatch: React.Dispatch<ICreatedAction>
+) => {
+  const user = await API.getUserById(userId);
+  dispatch(login(user));
+};
+
 /**
  * Under here you will find action creators, the reducer, and created action creators.
  */
@@ -93,6 +101,7 @@ export const AuthActions = {
   doLogin,
   doLogout,
   doRegister,
+  doSetUser,
   doUpdateUser,
 };
 

--- a/src/store/reducers/company.ts
+++ b/src/store/reducers/company.ts
@@ -1,10 +1,18 @@
-import { ICompany } from '../../declarations/company';
+import { ICompany, ICompanyUser } from '../../declarations/company';
 
 import * as API from '../../mitochondria';
+import { IUpdateCompany } from '../../mitochondria';
 
 export type CompanyState = Array<ICompany>;
 
+// Actions
 const ADD_COMPANY = 'ADD_COMPANY' as const;
+const UPDATE_COMPANY = 'UPDATE_COMPANY' as const;
+const DELETE_COMPANY = 'DELETE_COMPANY' as const;
+const ADD_USER_TO_COMPANY = 'ADD_USER_TO_COMPANY' as const;
+const REMOVE_USER_FROM_COMPANY = 'REMOVE_USER_FROM_COMPANY' as const;
+const SET_ROLE_FOR_USER_IN_COMPANY = 'SET_ROLE_FOR_USER_IN_COMPANY' as const;
+
 const addCompany = (company: ICompany) => ({
   payload: company,
   type: ADD_COMPANY,
@@ -25,16 +33,90 @@ const doAddCompany = async (
   dispatch(addCompany(await API.getCompanyById(companyId)));
 };
 
+const updateCompany = (company: IUpdateCompany) => ({
+  payload: company,
+  type: UPDATE_COMPANY,
+});
+const doUpdateCompany = async (
+  company: IUpdateCompany,
+  dispatch: React.Dispatch<ICreatedAction>
+) => {
+  await API.updateCompany(company);
+  dispatch(updateCompany(company));
+};
+
+const deleteCompany = (companyId: number) => ({
+  payload: companyId,
+  type: DELETE_COMPANY,
+});
+const doDeleteCompany = async (
+  companyId: number,
+  dispatch: React.Dispatch<ICreatedAction>
+) => {
+  await API.deleteCompany(companyId);
+  dispatch(deleteCompany(companyId));
+};
+
+const addUserToCompany = (user: ICompanyUser) => ({
+  payload: user,
+  type: ADD_USER_TO_COMPANY,
+});
+const doAddUserToCompany = async (
+  user: ICompanyUser,
+  dispatch: React.Dispatch<ICreatedAction>
+) => {
+  await API.addUserToCompany(user);
+  dispatch(addUserToCompany(user));
+};
+
+const removeUserFromCompany = (companyId: number, userId: number) => ({
+  payload: {
+    companyId,
+    userId,
+  },
+  type: REMOVE_USER_FROM_COMPANY,
+});
+const doRemoveUserFromCompany = async (
+  companyId: number,
+  userId: number,
+  dispatch: React.Dispatch<ICreatedAction>
+) => {
+  await API.removeUserFromCompany(companyId, userId);
+  dispatch(removeUserFromCompany(companyId, userId));
+};
+
+const setRoleForUserInCompany = (user: ICompanyUser) => ({
+  payload: user,
+  type: SET_ROLE_FOR_USER_IN_COMPANY,
+});
+const doSetRoleForUserInCompany = async (
+  user: ICompanyUser,
+  dispatch: React.Dispatch<ICreatedAction>
+) => {
+  await API.setRoleForUserInCompany(user);
+  dispatch(setRoleForUserInCompany(user));
+};
+
 /**
  * Under here you will find action creators, the reducer, and created action creators.
  */
 
-const CompanyActionCreators = {
+export const CompanyActionCreators = {
   addCompany,
+  addUserToCompany,
+  deleteCompany,
+  removeUserFromCompany,
+  setRoleForUserInCompany,
+  updateCompany,
 };
 
 export const CompanyActions = {
   doAddCompany,
+  doAddUserToCompany,
+  doDeleteCompany,
+  doRemoveUserFromCompany,
+  doSetRoleForUserInCompany,
+  doUpdateCompany,
 };
 
 // the return types of all the elements in ActionCreators
@@ -50,6 +132,56 @@ export const companyReducer = (
   switch (action.type) {
     case ADD_COMPANY:
       return [action.payload, ...state];
+    case UPDATE_COMPANY:
+      return [
+        ...state.filter(e => e.id !== action.payload.company_id),
+        {
+          ...state.find(e => e.id === action.payload.company_id)!,
+          ...action.payload,
+        },
+      ];
+    case DELETE_COMPANY:
+      return state.filter(e => e.id !== action.payload);
+    case ADD_USER_TO_COMPANY:
+      const addUserCompany = state.find(
+        e => e.id === action.payload.company_id
+      )!;
+      return [
+        ...state.filter(e => e.id !== action.payload.company_id),
+        {
+          ...addUserCompany,
+          users: [...addUserCompany.users, action.payload],
+        },
+      ];
+    case REMOVE_USER_FROM_COMPANY:
+      const removeUserCompany = state.find(
+        e => e.id === action.payload.companyId
+      )!;
+      return [
+        ...state.filter(e => e.id !== action.payload.companyId),
+        {
+          ...removeUserCompany,
+          users: removeUserCompany.users.filter(
+            e => e.user_id !== action.payload.userId
+          ),
+        },
+      ];
+    case SET_ROLE_FOR_USER_IN_COMPANY:
+      const setRoleForUserInCompanyCompany = state.find(
+        e => e.id === action.payload.company_id
+      )!;
+      return [
+        ...state.filter(e => e.id !== action.payload.company_id),
+        {
+          ...setRoleForUserInCompanyCompany,
+          users: [
+            ...setRoleForUserInCompanyCompany.users.filter(
+              e => e.user_id !== action.payload.user_id
+            ),
+            action.payload,
+          ],
+        },
+      ];
   }
 
   return state;

--- a/src/store/reducers/company.ts
+++ b/src/store/reducers/company.ts
@@ -1,7 +1,6 @@
 import { ICompany, ICompanyUser } from '../../declarations/company';
 
 import * as API from '../../mitochondria';
-import { IUpdateCompany } from '../../mitochondria';
 
 export type CompanyState = Array<ICompany>;
 
@@ -33,12 +32,12 @@ const doAddCompany = async (
   dispatch(addCompany(await API.getCompanyById(companyId)));
 };
 
-const updateCompany = (company: IUpdateCompany) => ({
+const updateCompany = (company: API.IUpdateCompany) => ({
   payload: company,
   type: UPDATE_COMPANY,
 });
 const doUpdateCompany = async (
-  company: IUpdateCompany,
+  company: API.IUpdateCompany,
   dispatch: React.Dispatch<ICreatedAction>
 ) => {
   await API.updateCompany(company);

--- a/src/store/reducers/transactions.ts
+++ b/src/store/reducers/transactions.ts
@@ -23,7 +23,7 @@ const addTransaction = (tx: ITransaction) => ({
  * @param dispatch The dispatch method from the TransactionDispatchContext
  * @throws "Error if return code is not 201"
  */
-const doAddTransaction = async (
+const doCreateTransaction = async (
   newTransaction: api.ICreateTransaction,
   dispatch: TransactionDispatch
 ) => {

--- a/src/store/reducers/transactions.ts
+++ b/src/store/reducers/transactions.ts
@@ -3,47 +3,43 @@ import { ITransaction } from './../../declarations/transaction';
 import { TransactionDispatch } from './../contexts/transactions';
 
 // Action types
-const ADD_TRANSACTION = 'ADD_TRANSACTION';
-const REMOVE_TRANSACTION = 'REMOVE_TRANSACTION';
-const RESET_TRANSACTIONS = 'RESET_TRANSACTIONS'; // mostly for testing purposes.
-const INTERMEDIARY_ADD = 'INTERMEDIARY_ADD';
-const INTERMEDIARY_REMOVE = 'INTERMEDIARY_REMOVE';
+const REMOVE_TRANSACTION = 'REMOVE_TRANSACTION' as const;
+const RESET_TRANSACTIONS = 'RESET_TRANSACTIONS' as const; // mostly for testing purposes.
+const INTERMEDIARY_ADD = 'INTERMEDIARY_ADD' as const;
+const INTERMEDIARY_REMOVE = 'INTERMEDIARY_REMOVE' as const;
+const ADD_TRANSACTION = 'ADD_TRANSACTION' as const;
+const UPDATE_TRANSACTION = 'UPDATE_TRANSACTION' as const;
 
 // You need to define the return-type to have the typeof ADD_TRANSACTION as it will not be able to
 // infer that it is actually just a const string - by default it will infer a string.
 
-const addTransaction = (
-  tx: ITransaction
-): { type: typeof ADD_TRANSACTION; payload: ITransaction } => ({
+const addTransaction = (tx: ITransaction) => ({
   payload: tx,
   type: ADD_TRANSACTION,
 });
-
 /**
  * It posts the new transaction to the API and dispatches an ADD_TRANSACTION action if successful.
  * @param newTransaction The new transaction that is to be posted to the API
  * @param dispatch The dispatch method from the TransactionDispatchContext
  * @throws "Error if return code is not 201"
  */
-const doAddTransaction = async (
+const doCreateTransaction = async (
   newTransaction: api.ICreateTransaction,
   dispatch: TransactionDispatch
 ) => {
-  // All values are stored as hundreths in state and database.
-  newTransaction.money *= 100;
-
   const createdTransaction = await api.createTransaction(newTransaction);
   dispatch(addTransaction(createdTransaction));
 };
 
-const removeTransaction = (
-  tx: ITransaction
-): { type: typeof REMOVE_TRANSACTION; payload: ITransaction } => ({
-  payload: tx,
+const removeTransaction = (companyId: number, txId: number) => ({
+  payload: { companyId, txId },
   type: REMOVE_TRANSACTION,
 });
-const doRemoveTransaction = (tx: ITransaction, dispatch: TransactionDispatch) =>
-  dispatch(removeTransaction(tx));
+const doRemoveTransaction = (
+  companyId: number,
+  txId: number,
+  dispatch: TransactionDispatch
+) => dispatch(removeTransaction(companyId, txId));
 
 const resetTransactions = (
   init: Array<ITransaction> = []
@@ -56,9 +52,7 @@ const doResetTransactions = (
   dispatch: TransactionDispatch
 ) => dispatch(resetTransactions(init));
 
-const addToIntermediary = (
-  id: ITransaction['id']
-): { type: typeof INTERMEDIARY_ADD; payload: ITransaction['id'] } => ({
+const addToIntermediary = (id: ITransaction['id']) => ({
   payload: id,
   type: INTERMEDIARY_ADD,
 });
@@ -67,9 +61,7 @@ const doAddToIntermediary = (
   dispatch: TransactionDispatch
 ) => dispatch(addToIntermediary(id));
 
-const removeFromIntermediary = (
-  id: ITransaction['id']
-): { type: typeof INTERMEDIARY_REMOVE; payload: ITransaction['id'] } => ({
+const removeFromIntermediary = (id: ITransaction['id']) => ({
   payload: id,
   type: INTERMEDIARY_REMOVE,
 });
@@ -78,20 +70,121 @@ const doRemoveFromIntermediary = (
   dispatch: TransactionDispatch
 ) => dispatch(removeFromIntermediary(id));
 
+const doFetchTransaction = async (
+  companyId: number,
+  transactionId: number,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  const resp = await api.getTransaction(companyId, transactionId);
+  dispatch(addTransaction(resp));
+};
+
+const updateTransaction = (tx: ITransaction) => ({
+  payload: tx,
+  type: UPDATE_TRANSACTION,
+});
+const doUpdateTransaction = async (
+  tx: ITransaction,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  await api.updateTransaction(tx);
+  dispatch(updateTransaction(tx));
+};
+
+const doDeleteTransaction = async (
+  companyId: number,
+  txId: number,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  await api.deleteTransaction(companyId, txId);
+  dispatch(removeTransaction(companyId, txId));
+};
+
+const doGetAllTransactions = async (
+  companyId: number,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  const resp = await api.getAllTransactions(companyId);
+
+  for (const t of resp.results) {
+    dispatch(addTransaction(t));
+  }
+};
+
+const doGetTransactionsByDate = async (
+  companyId: number,
+  date: string,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  const resp = await api.getTransactionsByDate(companyId, date);
+
+  for (const t of resp.results) {
+    dispatch(addTransaction(t));
+  }
+};
+
+const doGetTransactionsByDateRange = async (
+  companyId: number,
+  startDate: string,
+  endDate: string,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  const resp = await api.getTransactionsByDateRange(
+    companyId,
+    startDate,
+    endDate
+  );
+
+  for (const t of resp.results) {
+    dispatch(addTransaction(t));
+  }
+};
+
+const doGetAllIncomeTransactions = async (
+  companyId: number,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  const resp = await api.getAllIncomeTransactions(companyId);
+
+  for (const t of resp.results) {
+    dispatch(addTransaction(t));
+  }
+};
+
+const doGetAllExpenseTransactions = async (
+  companyId: number,
+  dispatch: React.Dispatch<ActionType>
+) => {
+  const resp = await api.getAllExpenseTransactions(companyId);
+
+  for (const t of resp.results) {
+    dispatch(addTransaction(t));
+  }
+};
+
 export const TransactionActionCreators = {
   addToIntermediary,
   addTransaction,
   removeFromIntermediary,
   removeTransaction,
   resetTransactions,
+  updateTransaction,
 };
 
 export const TransactionActions = {
   doAddToIntermediary,
-  doAddTransaction,
+  doCreateTransaction,
+  doDeleteTransaction,
+  doFetchTransaction,
+  doGetAllExpenseTransactions,
+  doGetAllIncomeTransactions,
+  doGetAllTransactions,
+  doGetTransactionsByDate,
+  doGetTransactionsByDateRange,
   doRemoveFromIntermediary,
   doRemoveTransaction,
   doResetTransactions,
+  doUpdateTransaction,
 };
 
 /**
@@ -121,7 +214,9 @@ export const transactionReducer = (
       return {
         ...state,
         transactions: state.transactions.filter(
-          e => e.id !== action.payload.id
+          e =>
+            e.id !== action.payload.txId &&
+            e.company_id === action.payload.companyId
         ),
       };
     case INTERMEDIARY_ADD:
@@ -138,6 +233,14 @@ export const transactionReducer = (
       return {
         ...state,
         transactions: action.payload,
+      };
+    case UPDATE_TRANSACTION:
+      return {
+        ...state,
+        transactions: [
+          ...state.transactions.filter(e => e.id !== action.payload.id),
+          action.payload,
+        ],
       };
     default:
       return state;


### PR DESCRIPTION
Continuation of #101.

## Implementation and testing of reducers and corresponding actions
- [x] company
  - [x] test
- [x] auth
  - [x] test
- [x] transactions
  - [x] test
- [ ] recurring
  - [ ] test

-------------------------------------------

For now, I'm holding off on implementing recurring transactions, as their implementation is being discussed.

I also omitted implementing month and balance stores, as I believe for now it is better to simply fetch them when you need them, instead of keeping them in a store.

The reason for why `transaction`, `auth`, and `company` is stored in a store, is because their information is central to the entire application, and thus we can keep the request count to a minimum.