### PR TITLE
Unset filters after tests

### DIFF
--- a/src/components/molecules/__tests__/Filters.test.tsx
+++ b/src/components/molecules/__tests__/Filters.test.tsx
@@ -12,6 +12,7 @@ const dummyTxs = new Array(50).fill(0).map(createDummyTransaction);
 
 const Wrapper: React.FC = props => {
   const transactionDispatch = useTransactionDispatch();
+
   React.useEffect(() => {
     TransactionActions.doResetTransactions(dummyTxs, transactionDispatch);
   }, [transactionDispatch]);
@@ -43,6 +44,8 @@ test('Only show recurring', () => {
       dummyTxs.filter(t => t.recurring_transaction_id).length
     );
   });
+
+  fireEvent.click(getByLabelText('Only recurring?'));
 });
 
 test('Filter on description', () => {
@@ -67,6 +70,10 @@ test('Filter on description', () => {
     expect(queryAllByText(new RegExp(filter)).length).toBe(
       dummyTxs.filter(t => new RegExp(filter).test(t.description)).length
     );
+  });
+
+  fireEvent.change(getByLabelText('Description'), {
+    target: { value: '' },
   });
 });
 
@@ -99,5 +106,12 @@ test('Filter on date', () => {
           new Date(t.date) < new Date(toDate)
       ).length
     );
+  });
+
+  fireEvent.change(getByLabelText('From date'), {
+    target: { value: '1970-01-01' },
+  });
+  fireEvent.change(getByLabelText('To date'), {
+    target: { value: '2020-01-01' },
   });
 });


### PR DESCRIPTION
This fixes the mystical bug where sometimes a Filters.tsx test would
crash. The cause was that they are running in parallell, and somehow,
the filters state persists.